### PR TITLE
modified the oembed id coding for any namespace and commented out som…

### DIFF
--- a/includes/response_generator.inc
+++ b/includes/response_generator.inc
@@ -87,14 +87,6 @@ Class RespsonseGenerator
         elseif(empty ($width)){
             $width = $height * 1.309;
         }
-//        elseif(!empty($height) && !empty($width)){
-//            if($width > $height * 1.309){
-//                $width = $height * 1.309;
-//            }
-//            else{
-//                $height = $width / 1.309;
-//            }
-//        }
         
         if(empty($iframeHeight)) {
             $iframeHeight = $height; 
@@ -172,7 +164,7 @@ Class RespsonseGenerator
             $id = explode(":",$id);
             $id = $id[1];
            $encodedUrl = $this->base_url."/uuid/".$id."?ui=embed";                
-//	$encodedUrl = "https://dev.repository.ou.edu/uuid/9ab56f04-7210-5212-b3b7-c6ead8d53779?ui=embed";
+
             if($this->width > 0) {
                 $encodedUrl .= "&width=".$this->width;
             }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -1,11 +1,5 @@
 <?php
 
-/* 
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
-
 /**
  * Get the pid prefix based on URL alias
  */

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -1,0 +1,23 @@
+<?php
+
+/* 
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+/**
+ * Get the pid prefix based on URL alias
+ */
+function _get_pid_prefix($path){
+    $file_path = module_load_include('inc', 'content', 'includes/path');
+    if ($file_path === FALSE) {
+        return NULL;
+    }
+    $pid = drupal_lookup_path('source', $path, 'en');
+    $pid_arr = explode("/", $pid);
+    $pid_arr_length = count($pid_arr);
+    $pid = $pid_arr[$pid_arr_length-1];
+    $pid_arr = explode(":", $pid);
+    return $pid_arr[0];
+}

--- a/islandora_embed.module
+++ b/islandora_embed.module
@@ -21,20 +21,20 @@ function islandora_embed_menu() {
     'type' => MENU_CALLBACK,
     'access callback' => TRUE,
   );
-  $items['islandora/embed'] = array(
-    'title' => 'Islandora Embed',
-    'description' => "Interpret the embedding request and send back JSON objects",
-    'page callback' => 'islandora_embed',
-    'type' => MENU_CALLBACK,
-    'access callback' => TRUE,
-  );
-  $items['islandora/embed/maxwidth/%/maxheight/%/url/%'] = array(
-    'title' => 'Islandora Embed',
-    'description' => "Interpret the embedding request and send back JSON objects",
-    'page callback' => 'islandora_embed',
-    'type' => MENU_CALLBACK,
-    'access callback' => TRUE,
-  );
+//  $items['islandora/embed'] = array(
+//    'title' => 'Islandora Embed',
+//    'description' => "Interpret the embedding request and send back JSON objects",
+//    'page callback' => 'islandora_embed',
+//    'type' => MENU_CALLBACK,
+//    'access callback' => TRUE,
+//  );
+//  $items['islandora/embed/maxwidth/%/maxheight/%/url/%'] = array(
+//    'title' => 'Islandora Embed',
+//    'description' => "Interpret the embedding request and send back JSON objects",
+//    'page callback' => 'islandora_embed',
+//    'type' => MENU_CALLBACK,
+//    'access callback' => TRUE,
+//  );
   $items['islandora/embed/object/%islandora_object'] = array(
     'title' => 'Islandora Embed',
     'description' => "Send back JSON objects in response to oembed requests",
@@ -180,11 +180,15 @@ function uuid_embed_object() {
 }
 
 function getTranslatedUrl($url) {
+    module_load_include('inc', 'islandora_embed', 'includes/utilities');
     try{
         $url_arr = explode("/embed/uuid/",$url);
         $uuid = $url_arr[count($url_arr)-1];
-        $translatedUrl = $url_arr[0]."/islandora/embed/object/islandora%3A".$uuid;
-        //$translatedUrl = "/islandra/embed/object/islandora%3A".$uuid;
+	$uuid_arr = explode("?", $uuid);
+	$path = 'uuid/'.$uuid_arr[0];
+	$prefix = _get_pid_prefix($path);
+	$pid_prefix = urlencode($prefix.":");
+	$translatedUrl = $url_arr[0]."/islandora/embed/object/".$pid_prefix.$uuid;
         return $translatedUrl;
     }
     catch(Exception $ex){

--- a/islandora_embed.module
+++ b/islandora_embed.module
@@ -21,20 +21,7 @@ function islandora_embed_menu() {
     'type' => MENU_CALLBACK,
     'access callback' => TRUE,
   );
-//  $items['islandora/embed'] = array(
-//    'title' => 'Islandora Embed',
-//    'description' => "Interpret the embedding request and send back JSON objects",
-//    'page callback' => 'islandora_embed',
-//    'type' => MENU_CALLBACK,
-//    'access callback' => TRUE,
-//  );
-//  $items['islandora/embed/maxwidth/%/maxheight/%/url/%'] = array(
-//    'title' => 'Islandora Embed',
-//    'description' => "Interpret the embedding request and send back JSON objects",
-//    'page callback' => 'islandora_embed',
-//    'type' => MENU_CALLBACK,
-//    'access callback' => TRUE,
-//  );
+
   $items['islandora/embed/object/%islandora_object'] = array(
     'title' => 'Islandora Embed',
     'description' => "Send back JSON objects in response to oembed requests",

--- a/islandora_embed.module
+++ b/islandora_embed.module
@@ -134,6 +134,10 @@ function islandora_embed_object_UI(AbstractFedoraObject $object) {
   $resGenerator->getEmbeddedObjUI();
 }
 
+/**
+* Interpret and the request and get the URL pattern
+* '/islandora/embed/object/islandora%3Auuid?height=h&width=w' and redirect the request to the interpreted URL
+*/
 function uuid_embed_object() {
   $parameters = array();
   $parameters_string = $_SERVER['QUERY_STRING'];
@@ -166,6 +170,9 @@ function uuid_embed_object() {
   exit();
 }
 
+/**
+* Translate the url pattern from '/embed/uuid/uuid' to '/islandora/embed/object/islandora%3Auuid'
+*/
 function getTranslatedUrl($url) {
     module_load_include('inc', 'islandora_embed', 'includes/utilities');
     try{


### PR DESCRIPTION
The Drupal path module contains the function to query into the table containing the translation information from url alias to system path. So what I did was to use the alias, e.g. ‘uuid/sdf-eee-444’, to get the full length object pid, e.g. ’namespace:sdf-eee-444', and cut the full length pid to get the namespace. There should be no need to use the hard-coded namespace any more.